### PR TITLE
Explicitly set version in curl command

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -9,7 +9,7 @@ ARCHIVE_NAME = "freetds-0.91.112"
 
   puts "-----> Fetching & Extracting FreeTDS"
   puts `mkdir -p #{CACHE_DIR}`
-  puts `curl ftp://ftp.freetds.org/pub/freetds/stable/freetds-patched.tar.gz -o - | tar -xz -C #{CACHE_DIR} -f -`
+  puts `curl ftp://ftp.freetds.org/pub/freetds/stable/#{ARCHIVE_NAME}.tar.gz -o - | tar -xz -C #{CACHE_DIR} -f -`
 
   puts "-----> Configurating FreeTDS"
   puts `mkdir -p #{BUILD_DIR}/vendor/freetds`


### PR DESCRIPTION
When building, I received this error: `remote: sh: 1: cd: can't cd to /cache/freetds-0.91.112`.

Turns out that the command, pulling `freetds-patched` instead of `#{ARCHIVE_NAME}`, was getting `freetds-0.95.0`, so there was no `freetds-0.91.112` to `cd` into. This change sets the version to download explicitly, to avoid version conflicts like these.
